### PR TITLE
Bugfix for prediction unbiasedness

### DIFF
--- a/R/predict_couterfactual.R
+++ b/R/predict_couterfactual.R
@@ -52,9 +52,9 @@ predict_counterfactual.lm <- function(fit, treatment, data = find_data(fit)) {
   group_idx <- split(seq_len(nrow(data)), strata)
 
   if (identical(trt_vars$schema, "ps")) {
-    ret <- ret - bias(residual, data[[trt_vars$treatment]], group_idx)
+    ret <- ret + bias(residual, data[[trt_vars$treatment]], group_idx)
   } else {
-    ret <- ret - bias(residual, data[[trt_vars$treatment]], list(seq_len(nrow(ret))))
+    ret <- ret + bias(residual, data[[trt_vars$treatment]], list(seq_len(nrow(ret))))
   }
   structure(
     .Data = colMeans(ret),

--- a/R/predict_couterfactual.R
+++ b/R/predict_couterfactual.R
@@ -59,8 +59,8 @@ predict_counterfactual.lm <- function(fit, treatment, data = find_data(fit)) {
 
   # Create residual based on the
   # prediction-unbiased response
-  residual <- vector(length=nrow(ret), mode="numeric")
-  for(i in 1:length(trt_lvls)){
+  residual <- vector(length = nrow(ret), mode = "numeric")
+  for (i in 1:length(trt_lvls)) {
     trt_idx <- which(data$treatment == trt_lvls[i])
     residual[trt_idx] <- y[trt_idx] - ret[trt_idx, i]
   }

--- a/tests/testthat/test-predict_counterfactual.R
+++ b/tests/testthat/test-predict_counterfactual.R
@@ -10,6 +10,25 @@ test_that("predict_counterfactual works for binomial", {
   expect_snapshot(predict_counterfactual(fit_binom, treatment ~ 1))
 })
 
+test_that("predict_counterfactual works for negative binomial --
+          this tests that the prediction unbiasedness correction is working correctly", {
+  fit <- glm(y_b ~ treatment * covar, data=dummy_data, family=negative.binomial(theta=1))
+  pc <- predict_counterfactual(fit, treatment ~ 1, data=find_data(fit))
+  predictions <- attr(pc, "predictions")
+
+  # Check that the mean of the predicted outcomes within
+  # each treatment group matches with the observed outcomes
+  trt_levels <- levels(dummy_data$treatment)
+  for(i in 1:length(trt_levels)){
+    idx <- dummy_data$treatment == trt_levels[i]
+    # mean of the predicted outcomes within treatment group i
+    pred_mean <- mean(predictions[idx, i])
+    # mean of the y's within treatment group i
+    obs_mean <- mean(dummy_data[idx,][["y_b"]])
+    expect_equal(pred_mean, obs_mean, tolerance=1e-15)
+  }
+})
+
 test_that("predict_counterfactual works if contrast are non-standard", {
   dummy_data2 <- dummy_data
   dummy_data2$s1 <- as.ordered(dummy_data2$s1)

--- a/tests/testthat/test-predict_counterfactual.R
+++ b/tests/testthat/test-predict_counterfactual.R
@@ -12,20 +12,20 @@ test_that("predict_counterfactual works for binomial", {
 
 test_that("predict_counterfactual works for negative binomial --
           this tests that the prediction unbiasedness correction is working correctly", {
-  fit <- glm(y_b ~ treatment * covar, data=dummy_data, family=negative.binomial(theta=1))
-  pc <- predict_counterfactual(fit, treatment ~ 1, data=find_data(fit))
+  fit <- glm(y_b ~ treatment * covar, data = dummy_data, family = negative.binomial(theta = 1))
+  pc <- predict_counterfactual(fit, treatment ~ 1, data = find_data(fit))
   predictions <- attr(pc, "predictions")
 
   # Check that the mean of the predicted outcomes within
   # each treatment group matches with the observed outcomes
   trt_levels <- levels(dummy_data$treatment)
-  for(i in 1:length(trt_levels)){
+  for (i in 1:length(trt_levels)) {
     idx <- dummy_data$treatment == trt_levels[i]
     # mean of the predicted outcomes within treatment group i
     pred_mean <- mean(predictions[idx, i])
     # mean of the y's within treatment group i
-    obs_mean <- mean(dummy_data[idx,][["y_b"]])
-    expect_equal(pred_mean, obs_mean, tolerance=1e-15)
+    obs_mean <- mean(dummy_data[idx, ][["y_b"]])
+    expect_equal(pred_mean, obs_mean, tolerance = 1e-15)
   }
 })
 

--- a/tests/testthat/test-predict_counterfactual.R
+++ b/tests/testthat/test-predict_counterfactual.R
@@ -33,7 +33,7 @@ test_that("predict_counterfactual works for negative binomial --
   # were not aligned properly when predictions were biased
   residuals <- attr(pc, "residual")
   res_mean <- mean(residuals[idx])
-  expect_equal(res_mean, 0, tolerance=1e-15)
+  expect_equal(res_mean, 0, tolerance = 1e-15)
 })
 
 test_that("predict_counterfactual works if contrast are non-standard", {

--- a/tests/testthat/test-predict_counterfactual.R
+++ b/tests/testthat/test-predict_counterfactual.R
@@ -27,6 +27,13 @@ test_that("predict_counterfactual works for negative binomial --
     obs_mean <- mean(dummy_data[idx, ][["y_b"]])
     expect_equal(pred_mean, obs_mean, tolerance = 1e-15)
   }
+
+  # check that the mean of the residuals is zero within a treatment group
+  # this test exists because previously residual and predictions attributes
+  # were not aligned properly when predictions were biased
+  residuals <- attr(pc, "residual")
+  res_mean <- mean(residuals[idx])
+  expect_equal(res_mean, 0, tolerance=1e-15)
 })
 
 test_that("predict_counterfactual works if contrast are non-standard", {


### PR DESCRIPTION
# Issue 1

With G-computation, the prediction for an individual for group $$a$$ is $$\hat{\mu}_a(X_i)$$. To correct for prediction bias, with non-canonical link functions (as in the `negative.binomial()` family), the prediction should add on the mean residual for treatment group $$a$$, rather than subtract it, because the resulting AIPW estimator should be:

<img width="262" alt="Screenshot 2024-12-13 at 4 20 50 PM" src="https://github.com/user-attachments/assets/261cc2aa-cfbf-4354-b28b-b78b5470b322" />

Added a test to ensure that, after correction, the mean of the predictions within each treatment group match the mean of the observed outcomes (definition of prediction unbiasedness).

# Issue 2

The prediction unbiasedness correction was not being propagated to the "residual" attribute of the `predict_counterfactual` object. It was using the raw residuals. This matters because when calculating the variance under anything other than simple randomization, the residual attribute is used within the `vcovG` function.

I calculated the corrected residuals and used those in place of the original residuals, and I also added a test to ensure the correct behavior. The mean of the residuals attribute should be 0 within a treatment group.