### PR TITLE
Fix for wrong estimates with relabelled factors

### DIFF
--- a/R/predict_couterfactual.R
+++ b/R/predict_couterfactual.R
@@ -57,6 +57,7 @@ predict_counterfactual.lm <- function(fit, treatment, data = find_data(fit), vco
   )
 
   df[[trt_vars$treatment]] <- rep(trt_lvls, each = nrow(data))
+  df[[trt_vars$treatment]] <- factor(df[[trt_vars$treatment]], levels = trt_lvls)
 
   mm <- model.matrix(fit, data = df)
   pred_linear <- mm %*% coefficients(fit)

--- a/R/predict_couterfactual.R
+++ b/R/predict_couterfactual.R
@@ -56,8 +56,7 @@ predict_counterfactual.lm <- function(fit, treatment, data = find_data(fit), vco
     }
   )
 
-  df[[trt_vars$treatment]] <- rep(trt_lvls, each = nrow(data))
-  df[[trt_vars$treatment]] <- factor(df[[trt_vars$treatment]], levels = trt_lvls)
+  df[[trt_vars$treatment]] <- gl(n = n_lvls, k = nrow(data), labels = trt_lvls)
 
   mm <- model.matrix(fit, data = df)
   pred_linear <- mm %*% coefficients(fit)

--- a/tests/testthat/test-predict_counterfactual.R
+++ b/tests/testthat/test-predict_counterfactual.R
@@ -63,3 +63,16 @@ test_that("confint method for prediction_cf works as expected", {
     confint(predict_counterfactual(fit_binom, treatment = treatment ~ s1, eff_measure = h_diff))
   )
 })
+
+
+test_that("predict_counterfactual works for treatment factor levels in non-alphabetical order", {
+  expected_result <- predict_counterfactual(fit_glm, treatment ~ 1)
+
+  relabel_dat <- find_data(fit_glm)
+  levels(relabel_dat$treatment)[1] <- "trtpbo"
+  result_relabel <- predict_counterfactual(fit_glm, treatment ~ 1, data = relabel_dat)
+
+  expected <- expected_result$estimate
+  names(expected)[1] <- "trtpbo"
+  expect_equal(expected, result_relabel$estimate)
+})


### PR DESCRIPTION
The source of the bug is surprising to me, because I thought that `model.matrix` would properly apply the `xlevels` from `fit` to the new counterfactual data `df`, but it doesn't seem to...

See #69 